### PR TITLE
Fix/npc movement

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3267,7 +3267,7 @@ bool Unit::isInAccessiblePlaceFor(Creature const* c) const
     bool isInWater = (liquidStatus & MAP_LIQUID_STATUS_IN_CONTACT) != 0;
 
     // In water or jumping in water
-    if (isInWater || (liquidStatus == LIQUID_MAP_ABOVE_WATER && (IsFalling() || (ToPlayer() && ToPlayer()->IsFalling()))))
+    if (isInWater || (liquidStatus == LIQUID_MAP_ABOVE_WATER && IsFalling()))
         return c->CanEnterWater();
     else
         return c->CanWalk() || c->CanFly();
@@ -8725,8 +8725,12 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
         case MOVE_FLIGHT:
         {
             // Set creature speed rate
-            if (GetTypeId() == TYPEID_UNIT)
-                speed *= ToCreature()->GetCreatureTemplate()->speed_run;    // at this point, MOVE_WALK is never reached
+            if (GetTypeId() == TYPEID_UNIT) {
+                if (!IsHunterPet())
+                    speed *= ToCreature()->GetCreatureTemplate()->speed_run;    // at this point, MOVE_WALK is never reached
+                else
+                    speed *= 1.14286f; // Is there a smarter way?
+            }
 
             // Normalize speed by 191 aura SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED if need
             /// @todo possible affect only on MOVE_RUN

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -43,6 +43,17 @@ static bool IsMutualChase(Unit* owner, Unit* target)
     return false;
 }
 
+inline float GetChaseRange(Unit const* owner, Unit const* target)
+{
+    float hitboxSum = owner->GetCombatReach() + target->GetCombatReach();
+
+    float hoverDelta = owner->GetHoverOffset() - target->GetHoverOffset();
+    if (hoverDelta != 0.0f)
+        return std::sqrt(std::max(hitboxSum * hitboxSum - hoverDelta * hoverDelta, 0.0f));
+
+    return hitboxSum;
+}
+
 static bool PositionOkay(Unit* owner, Unit* target, Optional<float> minDistance, Optional<float> maxDistance, Optional<ChaseAngle> angle)
 {
     float const distSq = owner->GetExactDistSq(target);
@@ -159,15 +170,17 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
         ;
     bool mutualChase = IsMutualChase(owner, target);
     bool const mutualTarget = target->GetVictim() == owner;
+    float const chaseRange = GetChaseRange(owner, target);
+    float const meleeRange = owner->GetMeleeRange(target);
     float const hitboxSum = owner->GetCombatReach() + target->GetCombatReach();
     float const minRange = _range ? _range->MinRange + hitboxSum : CONTACT_DISTANCE;
     float const minTarget = (_range ? _range->MinTolerance : 0.0f) + hitboxSum;
-    float const maxRange = _range ? _range->MaxRange + hitboxSum : owner->GetMeleeRange(target); // melee range already includes hitboxes
+    float const maxRange = _range ? _range->MaxRange + hitboxSum :meleeRange; // melee range already includes hitboxes
     float const maxTarget = _range ? _range->MaxTolerance + hitboxSum : CONTACT_DISTANCE + hitboxSum;
     Optional<ChaseAngle> angle = mutualChase ? Optional<ChaseAngle>() : _angle;
 
     // Prevent almost infinite spinning of mutual targets.
-    if (angle && !mutualChase && _mutualChase && mutualTarget && minRange < maxRange)
+    if (angle && !mutualChase && mutualTarget && chaseRange < meleeRange)
     {
         angle = Optional<ChaseAngle>();
         mutualChase = true;


### PR DESCRIPTION
Hunter pet follows better and seems to path better (ProjectEpoch).

Caster npcs no longer spin infinitely with your pet while they cast. `_mutualChase` was returning false, not sure why but doesn't appear to be used anywhere else. Might need to revert this back and figure out why it was getting set (seemingly) incorrectly.

NPC pathing is still a bit goofy at times when navigating drastic elevation changes in terrain. There's still more to be done there. I think the problem is with path generation.